### PR TITLE
Message Overload issue

### DIFF
--- a/src/main/java/com/jenkov/nioserver/Message.java
+++ b/src/main/java/com/jenkov/nioserver/Message.java
@@ -94,6 +94,7 @@ public class Message {
         int lengthOfPartialMessage     = (message.offset + message.length) - endIndex;
 
         System.arraycopy(message.sharedArray, startIndexOfPartialMessage, this.sharedArray, this.offset, lengthOfPartialMessage);
+        this.length=this.length+lengthOfPartialMessage;
     }
 
     public int writeToByteBuffer(ByteBuffer byteBuffer){


### PR DESCRIPTION
when the buffer is more then one whole message,copy the overload buffer to the new message object.
The issue is after copy,the length of new message object should init its lenth value.
Is that right？
Look forward for your reply!